### PR TITLE
Export Not Type

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -5,10 +5,10 @@ import "testing"
 
 type Expect struct {
 	To  *To
-	Not *not
+	Not *Not
 }
 
-type not struct {
+type Not struct {
 	To *To
 }
 
@@ -29,7 +29,7 @@ func New(t *testing.T) func(v interface{}) *Expect {
 		nto = To{t, &nbe, &nhave, &nto, v, false}
 		return &Expect{
 			To:  &to,
-			Not: &not{&nto},
+			Not: &Not{&nto},
 		}
 	}
 }


### PR DESCRIPTION
The `Not` field of `Expect` was exported, but the type was not; at minimum, this was making the documentation a little difficult to read.
