### PR TITLE
Fix Sprint Call in Equal

### DIFF
--- a/to.go
+++ b/to.go
@@ -59,7 +59,7 @@ func (t *To) Match(s string) *To {
 
 // Assert two values are equals(deeply)
 func (t *To) Equal(exp interface{}) *To {
-	msg := t.msg(Sprint("equal to %v", exp))
+	msg := t.msg(Sprintf("equal to %v", exp))
 	if reflect.DeepEqual(t.actual, exp) != t.assert {
 		t.Error(msg)
 	}


### PR DESCRIPTION
The output I was getting from Equal included a "%v" - looks like it was using Sprint instead of Sprintf.
