### PR TITLE
Fix Naive Else Bug

### DIFF
--- a/be.go
+++ b/be.go
@@ -13,7 +13,7 @@ type Be struct {
 	assert bool
 }
 
-func NewBe(t T, e *Else, actual interface{}, assert bool) *Be {
+func newBe(t T, e *Else, actual interface{}, assert bool) *Be {
 	be := &Be{
 		Else:   e,
 		t:      t,

--- a/be.go
+++ b/be.go
@@ -13,9 +13,9 @@ type Be struct {
 	assert bool
 }
 
-func NewBe(t T, actual interface{}, assert bool) *Be {
+func NewBe(t T, e *Else, actual interface{}, assert bool) *Be {
 	be := &Be{
-		Else:   NewElse(t),
+		Else:   e,
 		t:      t,
 		actual: actual,
 		assert: assert,

--- a/be_test.go
+++ b/be_test.go
@@ -144,13 +144,13 @@ func TestBeFailNow(t *testing.T) {
 	expect(10).To.Be.Above(0).Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
-		t.Fatalf("Expected FailNow() on passing test not to be called")
+		t.Errorf("Expected FailNow() on passing test not to be called")
 	default:
 	}
 	expect(10).To.Be.Above(20).Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
 	default:
-		t.Fatalf("Expected FailNow() on failing test to be called")
+		t.Errorf("Expected FailNow() on failing test to be called")
 	}
 }

--- a/else.go
+++ b/else.go
@@ -5,7 +5,7 @@ type Else struct {
 	failed bool
 }
 
-func NewElse(t T) *Else {
+func newElse(t T) *Else {
 	return &Else{
 		t: t,
 	}

--- a/expect.go
+++ b/expect.go
@@ -19,8 +19,8 @@ type Not struct {
 func New(t T) func(v interface{}) *Expect {
 	return func(v interface{}) *Expect {
 		return &Expect{
-			To:  NewTo(t, v, true),
-			Not: &Not{To: NewTo(t, v, false)},
+			To:  newTo(t, v, true),
+			Not: &Not{To: newTo(t, v, false)},
 		}
 	}
 }

--- a/have.go
+++ b/have.go
@@ -13,7 +13,7 @@ type Have struct {
 	assert bool
 }
 
-func NewHave(t T, e *Else, actual interface{}, assert bool) *Have {
+func newHave(t T, e *Else, actual interface{}, assert bool) *Have {
 	have := &Have{
 		Else:   e,
 		t:      t,

--- a/have.go
+++ b/have.go
@@ -13,13 +13,13 @@ type Have struct {
 	assert bool
 }
 
-func NewHave(t T, actual interface{}, assert bool) *Have {
+func NewHave(t T, e *Else, actual interface{}, assert bool) *Have {
 	have := &Have{
+		Else:   e,
 		t:      t,
 		actual: actual,
 		assert: assert,
 	}
-	have.Else = NewElse(t)
 	have.And = have
 	return have
 }

--- a/have_test.go
+++ b/have_test.go
@@ -124,14 +124,14 @@ func TestHaveFailNow(t *testing.T) {
 	expect(l).To.Have.Len(1).Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
-		t.Fatalf("Expected FailNow() on passing test not to be called")
+		t.Errorf("Expected FailNow() on passing test not to be called")
 	default:
 	}
 	expect(l).To.Have.Len(3).Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
 	default:
-		t.Fatalf("Expected FailNow() on failing test to be called")
+		t.Errorf("Expected FailNow() on failing test to be called")
 	}
 }
 
@@ -142,13 +142,13 @@ func TestNotHaveFailNow(t *testing.T) {
 	expect(l).Not.To.Have.Len(3).Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
-		t.Fatalf("Expected FailNow() on passing test not to be called")
+		t.Errorf("Expected FailNow() on passing test not to be called")
 	default:
 	}
 	expect(l).Not.To.Have.Len(1).Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
 	default:
-		t.Fatalf("Expected FailNow() on failing test to be called")
+		t.Errorf("Expected FailNow() on failing test to be called")
 	}
 }

--- a/to.go
+++ b/to.go
@@ -23,9 +23,9 @@ func NewTo(t T, actual interface{}, assert bool) *To {
 		actual: actual,
 		assert: assert,
 	}
-	to.Be = NewBe(t, actual, assert)
-	to.Have = NewHave(t, actual, assert)
 	to.Else = NewElse(t)
+	to.Be = NewBe(t, to.Else, actual, assert)
+	to.Have = NewHave(t, to.Else, actual, assert)
 	to.And = to
 	return to
 }

--- a/to.go
+++ b/to.go
@@ -17,15 +17,15 @@ type To struct {
 	assert bool
 }
 
-func NewTo(t T, actual interface{}, assert bool) *To {
+func newTo(t T, actual interface{}, assert bool) *To {
 	to := &To{
 		t:      t,
 		actual: actual,
 		assert: assert,
 	}
-	to.Else = NewElse(t)
-	to.Be = NewBe(t, to.Else, actual, assert)
-	to.Have = NewHave(t, to.Else, actual, assert)
+	to.Else = newElse(t)
+	to.Be = newBe(t, to.Else, actual, assert)
+	to.Have = newHave(t, to.Else, actual, assert)
 	to.And = to
 	return to
 }

--- a/to_test.go
+++ b/to_test.go
@@ -65,14 +65,14 @@ func TestToFailNow(t *testing.T) {
 	expect("foo").To.Equal("foo").Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
-		t.Fatalf("Expected FailNow() on passing test not to be called")
+		t.Errorf("Expected FailNow() on passing test not to be called")
 	default:
 	}
 	expect("foo").To.Equal("bar").Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
 	default:
-		t.Fatalf("Expected FailNow() on failing test to be called")
+		t.Errorf("Expected FailNow() on failing test to be called")
 	}
 }
 
@@ -82,13 +82,35 @@ func TestNotToFailNow(t *testing.T) {
 	expect("foo").Not.To.Equal("bar").Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
-		t.Fatalf("Expected FailNow() on passing test not to be called")
+		t.Errorf("Expected FailNow() on passing test not to be called")
 	default:
 	}
 	expect("foo").Not.To.Equal("foo").Else.FailNow()
 	select {
 	case <-mockT.FailNowCalled:
 	default:
-		t.Fatalf("Expected FailNow() on failing test to be called")
+		t.Errorf("Expected FailNow() on failing test to be called")
+	}
+}
+
+func TestToAndHaveFailNow(t *testing.T) {
+	mockT := newMockT()
+	expect := expect.New(mockT)
+	expect("foo").To.Equal("bar").And.Have.Len(3).Else.FailNow()
+	select {
+	case <-mockT.FailNowCalled:
+	default:
+		t.Errorf("Expected FailNow() on failing test to be called")
+	}
+}
+
+func TestToAndBeFailNow(t *testing.T) {
+	mockT := newMockT()
+	expect := expect.New(mockT)
+	expect("foo").To.Equal("bar").And.Be.String().Else.FailNow()
+	select {
+	case <-mockT.FailNowCalled:
+	default:
+		t.Errorf("Expected FailNow() on failing test to be called")
 	}
 }


### PR DESCRIPTION
@a8m Are you okay with unexporting the `NewTo`, `NewHave`, `NewBe`, and `NewElse` functions?  I added them as part of the updates over the weekend, but they shouldn't have been exported.  If you'd rather leave them exported, I can certainly roll back my most recent commit.

I don't think it's a big deal, though, since they're new as of yesterday.

Resolves #13 
