### PR TITLE
Add Matcher type and To.Pass to accept it

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -1,9 +1,49 @@
 package expect
 
+// T is a type that we can perform assertions with.
 type T interface {
 	Errorf(format string, args ...interface{})
 	Fatal(...interface{})
 	FailNow()
+}
+
+// Matcher is any type which can perform matches against an actual
+// value.  A non-nil error means a failed match, and its Error()
+// method should return a suffix that finishes the prefix,
+// "Expected {actual} to ".
+//
+// Note that for negated matches (expect(foo).Not...), the matcher
+// itself will be printed out using %#v syntax.  If you would like
+// to customize your output, implement fmt.GoStringer.
+//
+// Example:
+//
+//     type StatusCodeMatcher int
+//
+//     func (m StatusCodeMatcher) Match(actual interface{}) error {
+//         resp, ok := actual.(*http.Response)
+//         if !ok {
+//             // "Expected {actual} to be of type *http.Response"
+//             return errors.New("be of type *http.Response")
+//         }
+//         if resp.StatusCode != int(m) {
+//             // "Expected {actual} to have a response code {m}"
+//             return fmt.Errorf("have a response code of %d", m)
+//         }
+//         return nil
+//     }
+//
+//     // GoString returns representation for m in a negated state,
+//     // e.g. where a value was *not* supposed to match.
+//     func (m StatusCodeMatcher) GoString() string {
+//         return fmt.Sprintf("Status Code %d", m)
+//     }
+//
+//     // The eventual assertions:
+//     expect(resp).To.Pass(StatusCodeMatcher(http.StatusOK))
+//     expect(resp).Not.To.Pass(StatusCodeMatcher(http.StatusOK))
+type Matcher interface {
+	Match(actual interface{}) error
 }
 
 type Expect struct {

--- a/helheim_test.go
+++ b/helheim_test.go
@@ -40,3 +40,26 @@ func (m *mockT) Fatal(arg0 ...interface{}) {
 func (m *mockT) FailNow() {
 	m.FailNowCalled <- true
 }
+
+type mockMatcher struct {
+	MatchCalled chan bool
+	MatchInput  struct {
+		Actual chan interface{}
+	}
+	MatchOutput struct {
+		Ret0 chan error
+	}
+}
+
+func newMockMatcher() *mockMatcher {
+	m := &mockMatcher{}
+	m.MatchCalled = make(chan bool, 100)
+	m.MatchInput.Actual = make(chan interface{}, 100)
+	m.MatchOutput.Ret0 = make(chan error, 100)
+	return m
+}
+func (m *mockMatcher) Match(actual interface{}) error {
+	m.MatchCalled <- true
+	m.MatchInput.Actual <- actual
+	return <-m.MatchOutput.Ret0
+}

--- a/to.go
+++ b/to.go
@@ -98,6 +98,21 @@ func (t *To) Panic(args ...interface{}) *To {
 	return t
 }
 
+func (t *To) Pass(matcher Matcher) *To {
+	err := matcher.Match(t.actual)
+	switch t.assert {
+	case true:
+		if err != nil {
+			t.fail(2, t.msg(err.Error()))
+		}
+	case false:
+		if err == nil {
+			t.fail(2, t.msg(fmt.Sprintf("match %#v", matcher)))
+		}
+	}
+	return t
+}
+
 func (t *To) fail(callers int, msg string) {
 	fail(t.t, callers+1, msg)
 	t.Else.failed = true


### PR DESCRIPTION
There is now a very simple `Matcher` type.  The `To` type has a corresponding `Pass` method which
takes a `Matcher`.

Resolves #14
