### PR TITLE
Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,19 @@ expect("foo").To.Equal("bar").Else.FailNow()
 ```go
 func TestFoo(t *testing.T) {
 	expect.Run(t, "SubFoo", func(expect expect.Expecter) {
-		expect("foo").To.Equal("bar")
+		expect("foo").To.Equal("foo")
+
+		// The expect package is shadowed, here, so we can't
+		// construct a function that requires an expect.Expecter.
+		// However, the expect.Expecter has a Run method that
+		// mirrors the functionality of the Run function, so
+		// we can still pass in functions constructed elsewhere.
+		expect.Run(t, "SubSubFoo", SomeOtherTest)
 	})
+}
+
+func SomeOtherTest(t *testing.T, expect expect.Expecter) {
+    expect("foo").To.Equal("bar")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ expect(func() {
 expect("foo").To.Equal("bar").Else.FailNow()
 ```
 
+## With go 1.7, we provide a Run function
+
+`Run` is just sugar for calling `t.Run` followed by `expect.New(subT)`.
+
+```go
+func TestFoo(t *testing.T) {
+	expect.Run(t, "SubFoo", func(expect expect.Expecter) {
+		expect("foo").To.Equal("bar")
+	})
+}
+```
+
 ## License
 MIT
 

--- a/be.go
+++ b/be.go
@@ -1,7 +1,7 @@
 package expect
 
 import (
-	. "fmt"
+	"fmt"
 	"reflect"
 )
 
@@ -26,7 +26,7 @@ func newBe(t T, e *Else, actual interface{}, assert bool) *Be {
 
 // Assert numeric value above the given value (> n)
 func (b *Be) Above(e float64) *Be {
-	msg := b.msg(Sprintf("above %v", e))
+	msg := b.msg(fmt.Sprintf("above %v", e))
 	if b.Num() > e != b.assert {
 		b.fail(2, msg)
 	}
@@ -35,7 +35,7 @@ func (b *Be) Above(e float64) *Be {
 
 // Assert numeric value below the given value (< n)
 func (b *Be) Below(e float64) *Be {
-	msg := b.msg(Sprintf("below %v", e))
+	msg := b.msg(fmt.Sprintf("below %v", e))
 	if b.Num() < e != b.assert {
 		b.fail(2, msg)
 	}
@@ -44,7 +44,7 @@ func (b *Be) Below(e float64) *Be {
 
 // Assert inclusive numeric range (<= to and >= from)
 func (b *Be) Within(from, to float64) *Be {
-	msg := b.msg(Sprintf("between range %v <= x <= %v", from, to))
+	msg := b.msg(fmt.Sprintf("between range %v <= x <= %v", from, to))
 	x := b.Num()
 	if x <= to && x >= from != b.assert {
 		b.fail(2, msg)
@@ -191,7 +191,7 @@ func (b *Be) Nil() *Be {
 
 // Assert given value is type of the given string
 func (b *Be) Type(s string) *Be {
-	msg := b.msg(Sprintf("type %v", s))
+	msg := b.msg(fmt.Sprintf("type %v", s))
 	if reflect.TypeOf(b.actual).Name() == s != b.assert {
 		b.fail(2, msg)
 	}

--- a/expect.go
+++ b/expect.go
@@ -1,15 +1,5 @@
 package expect
 
-import "testing"
-
-// T is a type that we can perform assertions with.
-type T interface {
-	Run(name string, test func(t *testing.T)) (succeeded bool)
-	Errorf(format string, args ...interface{})
-	Fatal(...interface{})
-	FailNow()
-}
-
 // Matcher is any type which can perform matches against an actual
 // value.  A non-nil error means a failed match, and its Error()
 // method should return a suffix that finishes the prefix,
@@ -69,13 +59,4 @@ func New(t T) Expecter {
 			Not: &Not{To: newTo(t, v, false)},
 		}
 	}
-}
-
-// Run acts like t.Run, but performs the `expect.New(t)` step for
-// you, passing in the resulting Expecter.
-func Run(t T, name string, expectation func(Expecter)) bool {
-	return t.Run(name, func(t *testing.T) {
-		expect := New(t)
-		expectation(expect)
-	})
 }

--- a/run.go
+++ b/run.go
@@ -1,0 +1,14 @@
+// +build go1.7
+
+package expect
+
+import "testing"
+
+// Run acts like t.Run, but performs the `expect.New(t)` step for
+// you, passing in the resulting Expecter.
+func Run(t T, name string, expectation func(Expecter)) bool {
+	return t.Run(name, func(t *testing.T) {
+		expect := New(t)
+		expectation(expect)
+	})
+}

--- a/run.go
+++ b/run.go
@@ -6,9 +6,15 @@ import "testing"
 
 // Run acts like t.Run, but performs the `expect.New(t)` step for
 // you, passing in the resulting Expecter.
-func Run(t T, name string, expectation func(Expecter)) bool {
+func Run(t T, name string, expectation func(*testing.T, Expecter)) bool {
 	return t.Run(name, func(t *testing.T) {
 		expect := New(t)
-		expectation(expect)
+		expectation(t, expect)
 	})
+}
+
+// Run is a convenience method for use when the expect package is
+// shadowed, e.g. `expect := expect.New(t)`.
+func (Expecter) Run(t T, name string, expectation func(*testing.T, Expecter)) bool {
+	return Run(t, name, expectation)
 }

--- a/run_test.go
+++ b/run_test.go
@@ -1,0 +1,40 @@
+package expect_test
+
+import (
+	"testing"
+
+	"github.com/a8m/expect"
+)
+
+func TestRun(t *testing.T) {
+	mockT := newMockT()
+	mockT.RunOutput.Succeeded <- true
+
+	called := false
+	ran := expect.Run(mockT, "Foo", func(expect expect.Expecter) {
+		called = true
+	})
+	if !ran {
+		t.Error("expect.Run returned false when t.Run returned true")
+	}
+	select {
+	case name := <-mockT.RunInput.Name:
+		if name != "Foo" {
+			t.Errorf(`%#v (actual) != "Foo" (expected)`, name)
+		}
+		test := <-mockT.RunInput.Test
+		test(t)
+		if !called {
+			t.Errorf(`Calling test %#v did not call passed in expectation func`, test)
+		}
+	default:
+		t.Error("expect.Run never called t.Run")
+	}
+
+	mockT.RunOutput.Succeeded <- false
+	ran = expect.Run(mockT, "Bar", func(expect expect.Expecter) {
+	})
+	if ran {
+		t.Error("expect.Run returned true when t.Run returned false")
+	}
+}

--- a/run_test.go
+++ b/run_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package expect_test
 
 import (

--- a/t.go
+++ b/t.go
@@ -1,0 +1,13 @@
+// +build go1.7
+
+package expect
+
+import "testing"
+
+// T is a type that we can perform assertions with.
+type T interface {
+	Run(name string, test func(t *testing.T)) (succeeded bool)
+	Errorf(format string, args ...interface{})
+	Fatal(...interface{})
+	FailNow()
+}

--- a/t.go16.go
+++ b/t.go16.go
@@ -1,0 +1,11 @@
+// +build !go1.7
+
+package expect
+
+// T is a type that we can perform assertions with.  This is the
+// pre-go1.7 version, which does not have a Run function.
+type T interface {
+	Errorf(format string, args ...interface{})
+	Fatal(...interface{})
+	FailNow()
+}


### PR DESCRIPTION
The advantage of providing our own Run function mostly boils down to the fact that we can
construct the `func(actual interface{}) *Expect` (now named `Expecter` because it's easier to type) for the calling code.  This slightly reduces repetition.

@jasonkeene and @a8m I'd appreciate any thoughts on this.  It's really just a small bit of sugar, but I kind of like the idea.  It's not adding a ton of value, though.
