### PR TITLE
Test against 1.6 and 1.7 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-go: 1.3
+go:
+- 1.6
+- 1.7
 install:
   - export PATH=$PATH:$HOME/gopath/bin
 scripts:


### PR DESCRIPTION
I just noticed that we were testing only against go 1.3 in travis.  This updates us to test against 1.6 and 1.7 (currently, the latest two versions).

@a8m I submitted this as a PR because I'm not sure if you have any code running on go 1.3; if so, that would seem like a valid reason to have travis run against 1.3.
