### PR TITLE
Add Expectation type and clean up a few things

### DIFF
--- a/be.go
+++ b/be.go
@@ -1,7 +1,7 @@
 package expect
 
 import (
-	. "fmt"
+	"fmt"
 	"reflect"
 )
 
@@ -26,7 +26,7 @@ func newBe(t T, e *Else, actual interface{}, assert bool) *Be {
 
 // Assert numeric value above the given value (> n)
 func (b *Be) Above(e float64) *Be {
-	msg := b.msg(Sprintf("above %v", e))
+	msg := b.msg(fmt.Sprintf("above %v", e))
 	if b.Num() > e != b.assert {
 		b.fail(2, msg)
 	}
@@ -35,7 +35,7 @@ func (b *Be) Above(e float64) *Be {
 
 // Assert numeric value below the given value (< n)
 func (b *Be) Below(e float64) *Be {
-	msg := b.msg(Sprintf("below %v", e))
+	msg := b.msg(fmt.Sprintf("below %v", e))
 	if b.Num() < e != b.assert {
 		b.fail(2, msg)
 	}
@@ -44,7 +44,7 @@ func (b *Be) Below(e float64) *Be {
 
 // Assert inclusive numeric range (<= to and >= from)
 func (b *Be) Within(from, to float64) *Be {
-	msg := b.msg(Sprintf("between range %v <= x <= %v", from, to))
+	msg := b.msg(fmt.Sprintf("between range %v <= x <= %v", from, to))
 	x := b.Num()
 	if x <= to && x >= from != b.assert {
 		b.fail(2, msg)
@@ -191,7 +191,7 @@ func (b *Be) Nil() *Be {
 
 // Assert given value is type of the given string
 func (b *Be) Type(s string) *Be {
-	msg := b.msg(Sprintf("type %v", s))
+	msg := b.msg(fmt.Sprintf("type %v", s))
 	if reflect.TypeOf(b.actual).Name() == s != b.assert {
 		b.fail(2, msg)
 	}

--- a/expect.go
+++ b/expect.go
@@ -46,17 +46,24 @@ type Matcher interface {
 	Match(actual interface{}) error
 }
 
+// Expect is the result of calling an Expectation with a value to assert
+// against.
 type Expect struct {
 	To  *To
 	Not *Not
 }
 
+// Not stores a To that is initialized to be the negation of the main To.
 type Not struct {
 	To *To
 }
 
-// Return new expect function with `To, To.Be, To.Have` assertions
-func New(t T) func(v interface{}) *Expect {
+// Expectation returns an Expect that is used to make assertions.
+type Expectation func(v interface{}) *Expect
+
+// New returns a function that can be given a value and have `To, To.Be,
+// To.Have` assertions chained onto it.
+func New(t T) Expectation {
 	return func(v interface{}) *Expect {
 		return &Expect{
 			To:  newTo(t, v, true),


### PR DESCRIPTION
The `Expectation` type has come up a few times. While using a8m/expect we have had to create this type in our testing packages a few times.

Additionally, I removed dot import for fmt and fixed some doc strings.