### PR TITLE
Add True and False methods to Be

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ expect([2]int{}).Not.To.Be.Empty()
 expect(val).To.Be.Ok()
 expect(false).Not.To.Be.Ok()
 
+// True/False
+expect(true).To.Be.True()
+expect(false).To.Be.False()
+
 // Type Assertion
 expect("").To.Be.String()
 expect(0).To.Be.Int()

--- a/be.go
+++ b/be.go
@@ -223,28 +223,28 @@ func (b *Be) Num() float64 {
 	}
 }
 
-func (b *Be) True() bool {
+func (b *Be) True() *Be {
 	v, err := b.bool()
 	if err != nil {
 		b.t.Fatal(invMsg("bool"))
-		return false
+		return b
 	}
 	if !v {
 		b.fail(2, b.msg("true"))
 	}
-	return v
+	return b
 }
 
-func (b *Be) False() bool {
+func (b *Be) False() *Be {
 	v, err := b.bool()
 	if err != nil {
 		b.t.Fatal(invMsg("bool"))
-		return false
+		return b
 	}
 	if v {
 		b.fail(2, b.msg("false"))
 	}
-	return v
+	return b
 }
 
 func (b *Be) bool() (bool, error) {

--- a/be.go
+++ b/be.go
@@ -1,6 +1,7 @@
 package expect
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 )
@@ -220,4 +221,38 @@ func (b *Be) Num() float64 {
 		b.t.Fatal(invMsg("numeric"))
 		return 0
 	}
+}
+
+func (b *Be) True() bool {
+	v, err := b.bool()
+	if err != nil {
+		b.t.Fatal(invMsg("bool"))
+		return false
+	}
+	if !v {
+		b.fail(2, b.msg("true"))
+	}
+	return v
+}
+
+func (b *Be) False() bool {
+	v, err := b.bool()
+	if err != nil {
+		b.t.Fatal(invMsg("bool"))
+		return false
+	}
+	if v {
+		b.fail(2, b.msg("false"))
+	}
+	return v
+}
+
+func (b *Be) bool() (bool, error) {
+	rv := reflect.ValueOf(b.actual)
+	switch rv.Kind() {
+	case reflect.Bool:
+		return rv.Bool(), nil
+	default:
+	}
+	return false, errors.New("not a bool")
 }

--- a/be_test.go
+++ b/be_test.go
@@ -51,6 +51,66 @@ func TestOk(t *testing.T) {
 	expect([]int{}).To.Be.Ok()
 }
 
+func TestTrue(t *testing.T) {
+	mockT := newMockT()
+	expect := expect.New(mockT)
+
+	expect(true).To.Be.True()
+	select {
+	case <-mockT.ErrorfCalled:
+		t.Errorf("Expected Errorf() on passing test not to be called")
+	case <-mockT.FatalCalled:
+		t.Errorf("Expected Fatal() on passing test not to be called")
+	case <-mockT.FailNowCalled:
+		t.Errorf("Expected FailNow() on passing test not to be called")
+	default:
+	}
+
+	expect(false).To.Be.True()
+	select {
+	case <-mockT.ErrorfCalled:
+	default:
+		t.Errorf("Expected Errorf() on failing test to be called")
+	}
+
+	expect(42).To.Be.True()
+	select {
+	case <-mockT.FatalCalled:
+	default:
+		t.Errorf("Expected Fatal() on failing test to be called")
+	}
+}
+
+func TestFalse(t *testing.T) {
+	mockT := newMockT()
+	expect := expect.New(mockT)
+
+	expect(false).To.Be.False()
+	select {
+	case <-mockT.ErrorfCalled:
+		t.Errorf("Expected Errorf() on passing test not to be called")
+	case <-mockT.FatalCalled:
+		t.Errorf("Expected Fatal() on passing test not to be called")
+	case <-mockT.FailNowCalled:
+		t.Errorf("Expected FailNow() on passing test not to be called")
+	default:
+	}
+
+	expect(true).To.Be.False()
+	select {
+	case <-mockT.ErrorfCalled:
+	default:
+		t.Errorf("Expected Errorf() on failing test to be called")
+	}
+
+	expect(42).To.Be.False()
+	select {
+	case <-mockT.FatalCalled:
+	default:
+		t.Errorf("Expected Fatal() on failing test to be called")
+	}
+}
+
 func TestString(t *testing.T) {
 	expect := expect.New(t)
 	expect("").To.Be.String()


### PR DESCRIPTION
This allows you to write:

`expect(true).To.Be.True()` and `expect(false).To.Be.False()`

This is more specific than `Ok` since the actual value must be of type bool.